### PR TITLE
Remove ulockmgr

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 cicpoffs:
-	${CXX} --std=c++17 cicpps.cpp fuse_launcher_gpl2.cpp -o cicpoffs -O2 -Wall $(shell pkg-config fuse3 libattr --cflags --libs) -lulockmgr -fPIC ${CXX_FLAGS}
+	${CXX} --std=c++17 cicpps.cpp fuse_launcher_gpl2.cpp -o cicpoffs -O2 -Wall $(shell pkg-config fuse3 libattr --cflags --libs) -fPIC ${CXX_FLAGS}
 
 install:
 	install -Dm755 cicpoffs ${DESTDIR}/usr/bin/cicpoffs

--- a/cicpoffs.cpp
+++ b/cicpoffs.cpp
@@ -10,7 +10,6 @@
 #include "cicpoffs.hpp"
 #include "cicpps.hpp"
 extern "C"{
-#include <ulockmgr.h>
 #include <errno.h>
 #include <stdio.h>
 #include <unistd.h>
@@ -63,7 +62,6 @@ static struct fuse_operations operations = {
 	.create = fuse_fn_create,
 	//.ftruncate = fuse_fn_ftruncate,
 	//.fgetattr = fuse_fn_fgetattr,
-	.lock = fuse_fn_lock,
 	.utimens = fuse_fn_utimens,
 	//.bmap = <unimplemented> - not for block devices,
 	//.ioctl = fuse_fn_ioctl,
@@ -328,10 +326,6 @@ int   (fuse_fn_fgetattr)    (const char* path, struct stat* st, struct fuse_file
 	int retval = fstat(ffi->fh, st);
 	if(retval==-1) return -errno;
 	return retval;
-};
-
-int   (fuse_fn_lock)        (const char* path, struct fuse_file_info* ffi, int cmd, struct flock* lock){
-	return ulockmgr_op(ffi->fh, cmd, lock, &ffi->lock_owner, sizeof(ffi->lock_owner));
 };
 
 int   (fuse_fn_utimens)     (const char* path, const struct timespec ts[2], struct fuse_file_info* ffi){

--- a/cicpoffs.hpp
+++ b/cicpoffs.hpp
@@ -48,7 +48,6 @@ int   (fuse_fn_access)      (const char*, int);
 int   (fuse_fn_create)      (const char*, mode_t, struct fuse_file_info*);
 //int   (fuse_fn_ftruncate)   (const char*, off_t, struct fuse_file_info*);
 //int   (fuse_fn_fgetattr)    (const char*, struct stat*, struct fuse_file_info*);
-int   (fuse_fn_lock)        (const char*, struct fuse_file_info*, int, struct flock*);
 int   (fuse_fn_utimens)     (const char*, const struct timespec[2], struct fuse_file_info*);
 int   (fuse_fn_bmap)        (const char*, size_t, uint64_t*);
 int   (fuse_fn_ioctl)       (const char*, int, void*, struct fuse_file_info*, unsigned int, void*);


### PR DESCRIPTION
Newer distros are only distributing FUSE3 libraries which drop `ulockmgr_server`. Since cicpoffs doesn't actually require the service in order to work (host OS provides locking), the code can safely be removed.