### PR TITLE
Explicitly enable use_ino

### DIFF
--- a/cicpoffs.cpp
+++ b/cicpoffs.cpp
@@ -94,7 +94,17 @@ void* (fuse_fn_init)        (struct fuse_conn_info* conn, struct fuse_config* cf
 		logmsg("Path must be absolute.");
 		exit(ENOENT);
 	}
-	
+	cfg->use_ino = 1;
+        /* Pick up changes from lower filesystem right away. This is
+           also necessary for better hardlink support. When the kernel
+           calls the unlink() handler, it does not know the inode of
+           the to-be-removed entry and can therefore not invalidate
+           the cache of the associated inode - resulting in an
+           incorrect st_nlink value being reported for any remaining
+           hardlinks to this inode. */
+        cfg->entry_timeout = 0;
+        cfg->attr_timeout = 0;
+        cfg->negative_timeout = 0;
 	return NULL;
 };
 


### PR DESCRIPTION
Explicitly enable the `use_ino` option so that files return the host file system's inode numbers. It appears that libfuse3 does not accept the `-o use_ino` command line option anymore.

This code is based on libfuse's `passthrough.c` example.